### PR TITLE
Support for detection modes and S3 buckets

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -12,6 +12,9 @@ class Image
     /** @var string */
     private $binaryContent;
 
+    /** @var string */
+    private $urlContent;
+
     /** @var Label[] */
     private $labels = [];
 
@@ -19,17 +22,9 @@ class Image
     private $texts = [];
 
     /**
-     * @param string $binaryContent
-     */
-    public function __construct(string $binaryContent)
-    {
-        $this->setBinaryContent($binaryContent);
-    }
-
-    /**
      * @return string
      */
-    public function getBinaryContent(): string
+    public function getBinaryContent(): ?string
     {
         return $this->binaryContent;
     }
@@ -40,6 +35,16 @@ class Image
     public function setBinaryContent(string $binaryContent): void
     {
         $this->binaryContent = $binaryContent;
+    }
+
+    public function getUrlContent(): ?string
+    {
+        return $this->urlContent;
+    }
+
+    public function setUrlContent(string $urlContent): void
+    {
+        $this->urlContent = $urlContent;
     }
 
     /**

--- a/src/Service/LabelService.php
+++ b/src/Service/LabelService.php
@@ -55,10 +55,33 @@ class LabelService
      */
     protected function getResult(Image $rekognitionImage)
     {
+        if ($rekognitionImage->getBinaryContent()) {
+            return $this->rekognitionClient->detectLabels(
+                [
+                    'Image' => [
+                        'Bytes' => $rekognitionImage->getBinaryContent(),
+                    ],
+                    'Attributes' => ['ALL']
+                ]
+            );
+        }
+
+        $url = $rekognitionImage->getUrlContent();
+        $parts = explode('s3.amazonaws.com', $url);
+        if (!count($parts)) {
+            throw new \Exception('Unable to parse S3 url');
+        }
+
+        $bucket = trim(substr($parts[1], 0, strpos($parts[1], '/', 1)), '/');
+        $name = substr($parts[1], (strpos($parts[1], '/', 1) + 1));
+
         return $this->rekognitionClient->detectLabels(
             [
                 'Image' => [
-                    'Bytes' => $rekognitionImage->getBinaryContent(),
+                    'S3Object' => [
+                        'Bucket' => $bucket,
+                        'Name' => $name
+                    ]
                 ],
                 'Attributes' => ['ALL']
             ]

--- a/src/Service/TextService.php
+++ b/src/Service/TextService.php
@@ -50,10 +50,33 @@ class TextService
      */
     protected function getResult(Image $rekognitionImage)
     {
-        return $this->rekognitionClient->detectText(
+        if ($rekognitionImage->getBinaryContent()) {
+            return $this->rekognitionClient->detectText(
+                [
+                    'Image' => [
+                        'Bytes' => $rekognitionImage->getBinaryContent(),
+                    ],
+                    'Attributes' => ['ALL']
+                ]
+            );
+        }
+
+        $url = $rekognitionImage->getUrlContent();
+        $parts = explode('s3.amazonaws.com', $url);
+        if (!count($parts)) {
+            throw new \Exception('Unable to parse S3 url');
+        }
+
+        $bucket = trim(substr($parts[1], 0, strpos($parts[1], '/', 1)), '/');
+        $name = substr($parts[1], (strpos($parts[1], '/', 1) + 1));
+
+        return $this->rekognitionClient->detectLabels(
             [
                 'Image' => [
-                    'Bytes' => $rekognitionImage->getBinaryContent(),
+                    'S3Object' => [
+                        'Bucket' => $bucket,
+                        'Name' => $name
+                    ]
                 ],
                 'Attributes' => ['ALL']
             ]


### PR DESCRIPTION
This PR adds support for detection via S3 buckets and the ability to change the detection mode.

`detectFromUrl` automatically looks for `s3.amazonaws.com` in URLs and switches from binary to S3 mode.

Also adds the following constants:

* `Service/DetectService::DETECT_BOTH`
* `Service/DetectService::DETECT_LABEL`
* `Service/DetectService::DETECT_TEXT`

and the following method

* `setDetectMode`

That allows you to limit it to text, labels or both (default).